### PR TITLE
Redo JsonAdaptedEntity

### DIFF
--- a/src/main/java/dog/pawbook/model/managedentity/Entity.java
+++ b/src/main/java/dog/pawbook/model/managedentity/Entity.java
@@ -4,7 +4,6 @@ import static dog.pawbook.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import dog.pawbook.model.managedentity.tag.Tag;
@@ -73,5 +72,4 @@ public abstract class Entity {
      */
     public abstract String[] getOtherPropertiesAsString();
 
-    public abstract Map<String, String> getOtherPropertiesAsDict();
 }

--- a/src/main/java/dog/pawbook/model/managedentity/dog/Dog.java
+++ b/src/main/java/dog/pawbook/model/managedentity/dog/Dog.java
@@ -3,8 +3,6 @@ package dog.pawbook.model.managedentity.dog;
 import static dog.pawbook.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -117,18 +115,6 @@ public class Dog extends Entity {
             tags.forEach(builder::append);
         }
         return builder.toString();
-    }
-
-    @Override
-    public Map<String, String> getOtherPropertiesAsDict() {
-        Map<String, String> dict = new HashMap<>();
-        dict.put("type", ENTITY_WORD);
-        dict.put(Breed.class.getSimpleName(), breed.value);
-        dict.put(DateOfBirth.class.getSimpleName(), dob.value);
-        dict.put(Sex.class.getSimpleName(), sex.value);
-        dict.put("owner_id", String.valueOf(ownerID));
-
-        return dict;
     }
 
     @Override

--- a/src/main/java/dog/pawbook/model/managedentity/owner/Owner.java
+++ b/src/main/java/dog/pawbook/model/managedentity/owner/Owner.java
@@ -2,8 +2,6 @@ package dog.pawbook.model.managedentity.owner;
 
 import static dog.pawbook.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -97,16 +95,5 @@ public class Owner extends Entity {
             tags.forEach(builder::append);
         }
         return builder.toString();
-    }
-
-    @Override
-    public Map<String, String> getOtherPropertiesAsDict() {
-        Map<String, String> dict = new HashMap<>();
-        dict.put("type", ENTITY_WORD);
-        dict.put(Phone.class.getSimpleName(), phone.value);
-        dict.put(Email.class.getSimpleName(), email.value);
-        dict.put(Address.class.getSimpleName(), address.value);
-
-        return dict;
     }
 }

--- a/src/main/java/dog/pawbook/storage/JsonAdaptedDog.java
+++ b/src/main/java/dog/pawbook/storage/JsonAdaptedDog.java
@@ -1,0 +1,99 @@
+package dog.pawbook.storage;
+
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import dog.pawbook.commons.exceptions.IllegalValueException;
+import dog.pawbook.model.managedentity.Entity;
+import dog.pawbook.model.managedentity.Name;
+import dog.pawbook.model.managedentity.dog.Breed;
+import dog.pawbook.model.managedentity.dog.DateOfBirth;
+import dog.pawbook.model.managedentity.dog.Dog;
+import dog.pawbook.model.managedentity.dog.Sex;
+import dog.pawbook.model.managedentity.tag.Tag;
+import javafx.util.Pair;
+
+@JsonTypeName("dog")
+public class JsonAdaptedDog extends JsonAdaptedEntity {
+    private final String breed;
+    private final String dob;
+    private final String sex;
+    private final int ownerid;
+
+    /**
+     * Constructs a {@code JsonAdaptedEntity} with the given owner details.
+     */
+    @JsonCreator
+    public JsonAdaptedDog(@JsonProperty("id") Integer id, @JsonProperty("name") String name,
+            @JsonProperty("breed") String breed, @JsonProperty("dob") String dob,
+            @JsonProperty("sex") String sex, @JsonProperty("ownerid") Integer ownerid,
+            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        super(id, name, tagged);
+        this.breed = breed;
+        this.dob = dob;
+        this.sex = sex;
+        this.ownerid = ownerid;
+    }
+
+    /**
+     * Converts a given {@code Entity} into this class for Jackson use.
+     */
+    public JsonAdaptedDog(Pair<Integer, Dog> idDogPair) {
+        super(idDogPair);
+        Dog source = idDogPair.getValue();
+        breed = source.getBreed().value;
+        dob = source.getDob().value;
+        sex = source.getSex().value;
+        ownerid = source.getOwnerId();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted entity object into the model's {@code Entity} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted entity.
+     */
+    @Override
+    public Pair<Integer, Entity> toModelType() throws IllegalValueException {
+        CommonAttributes commonAttributes = checkAndGetCommonAttributes();
+        final int modelID = commonAttributes.id;
+        final Name modelName = commonAttributes.name;
+        final Set<Tag> modelTags = commonAttributes.tags;
+
+        if (breed == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Breed.class.getSimpleName()));
+        }
+        if (!Breed.isValidBreed(breed)) {
+            throw new IllegalValueException(Breed.MESSAGE_CONSTRAINTS);
+        }
+        final Breed modelBreed = new Breed(breed);
+
+        if (dob == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    DateOfBirth.class.getSimpleName()));
+        }
+        if (!DateOfBirth.isValidDob(dob)) {
+            throw new IllegalValueException(DateOfBirth.MESSAGE_CONSTRAINTS);
+        }
+        final DateOfBirth modelDob = new DateOfBirth(dob);
+
+        if (sex == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Sex.class.getSimpleName()));
+        }
+        if (!Sex.isValidSex(sex)) {
+            throw new IllegalValueException(Sex.MESSAGE_CONSTRAINTS);
+        }
+        final Sex modelSex = new Sex(sex);
+
+        if (ownerid < 1) {
+            throw new IllegalValueException("Owner's ID must be a positive integer!");
+        }
+
+        Dog model = new Dog(modelName, modelBreed, modelDob, modelSex, ownerid, modelTags);
+
+        return new Pair<>(modelID, model);
+    }
+}

--- a/src/main/java/dog/pawbook/storage/JsonAdaptedOwner.java
+++ b/src/main/java/dog/pawbook/storage/JsonAdaptedOwner.java
@@ -1,0 +1,90 @@
+package dog.pawbook.storage;
+
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import dog.pawbook.commons.exceptions.IllegalValueException;
+import dog.pawbook.model.managedentity.Entity;
+import dog.pawbook.model.managedentity.Name;
+import dog.pawbook.model.managedentity.owner.Address;
+import dog.pawbook.model.managedentity.owner.Email;
+import dog.pawbook.model.managedentity.owner.Owner;
+import dog.pawbook.model.managedentity.owner.Phone;
+import dog.pawbook.model.managedentity.tag.Tag;
+import javafx.util.Pair;
+
+@JsonTypeName("owner")
+public class JsonAdaptedOwner extends JsonAdaptedEntity {
+    private final String phone;
+    private final String email;
+    private final String address;
+
+    /**
+     * Constructs a {@code JsonAdaptedEntity} with the given owner details.
+     */
+    @JsonCreator
+    public JsonAdaptedOwner(@JsonProperty("id") Integer id, @JsonProperty("name") String name,
+            @JsonProperty("phone") String phone, @JsonProperty("email") String email,
+            @JsonProperty("address") String address, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        super(id, name, tagged);
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+    }
+
+    /**
+     * Converts a given {@code Entity} into this class for Jackson use.
+     */
+    public JsonAdaptedOwner(Pair<Integer, Owner> idOwnerPair) {
+        super(idOwnerPair);
+        Owner source = idOwnerPair.getValue();
+        phone = source.getPhone().value;
+        email = source.getEmail().value;
+        address = source.getAddress().value;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted owner object into the model's {@code Owner} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted entity.
+     */
+    @Override
+    public Pair<Integer, Entity> toModelType() throws IllegalValueException {
+        CommonAttributes commonAttributes = checkAndGetCommonAttributes();
+        final int modelID = commonAttributes.id;
+        final Name modelName = commonAttributes.name;
+        final Set<Tag> modelTags = commonAttributes.tags;
+
+        if (phone == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
+        }
+        if (!Phone.isValidPhone(phone)) {
+            throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
+        }
+        final Phone modelPhone = new Phone(phone);
+
+        if (email == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
+        }
+        if (!Email.isValidEmail(email)) {
+            throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
+        }
+        final Email modelEmail = new Email(email);
+
+        if (address == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
+        }
+        if (!Address.isValidAddress(address)) {
+            throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
+        }
+        final Address modelAddress = new Address(address);
+
+        Owner model = new Owner(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+
+        return new Pair<>(modelID, model);
+    }
+}

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidOwnerAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidOwnerAddressBook.json
@@ -1,19 +1,17 @@
 {
   "entities": [ {
+    "type": "owner",
+    "id" : 1,
     "name": "Valid Owner",
-    "propertyDict": {
-      "phone": "9482424",
-      "email": "hans@example.com",
-      "address": "4th street",
-      "type": "owner"
-    }
+    "phone": "9482424",
+    "email": "hans@example.com",
+    "address": "4th street"
   }, {
+    "type": "owner",
+    "id" : 2,
     "name": "Owner With Invalid Phone Field",
-    "propertyDict": {
-      "phone": "948asdf2424",
-      "email": "hans@example.com",
-      "address": "4th street",
-      "type": "owner"
-    }
+    "phone": "948asdf2424",
+    "email": "hans@example.com",
+    "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidOwnerAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidOwnerAddressBook.json
@@ -1,12 +1,10 @@
 {
   "entities": [ {
-      "id": 1,
-      "name": "Owner with invalid name field: Ha!ns Mu@ster",
-      "propertyDict": {
-        "Phone": "9482424",
-        "Email": "hans@example.com",
-        "Address": "4th street",
-        "type": "owner"
-      }
+    "type": "owner",
+    "id": 1,
+    "name": "Owner with invalid name field: Ha!ns Mu@ster",
+    "phone": "9482424",
+    "email": "hans@example.com",
+    "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateOwnerAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateOwnerAddressBook.json
@@ -1,22 +1,18 @@
 {
   "entities": [ {
+    "type": "owner",
     "id": 1,
     "name": "Alice Pauline",
-    "propertyDict": {
-      "Phone": "94351253",
-      "Email": "alice@example.com",
-      "Address": "123, Jurong West Ave 6, #08-111",
-      "type": "owner"
-    },
+    "phone": "94351253",
+    "email": "alice@example.com",
+    "address": "123, Jurong West Ave 6, #08-111",
     "tagged": [ "friends" ]
   }, {
+    "type": "owner",
     "id": 2,
     "name": "Alice Pauline",
-    "propertyDict": {
-      "Phone": "94351253",
-      "Email": "pauline@example.com",
-      "Address": "4th street",
-      "type": "owner"
-    }
+    "phone": "94351253",
+    "email": "pauline@example.com",
+    "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidOwnerAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidOwnerAddressBook.json
@@ -1,12 +1,10 @@
 {
   "entities": [ {
+    "type": "owner",
     "id": 1,
     "name": "Hans Muster",
-    "propertyDict": {
-      "Phone": "9482424",
-      "Email": "invalid@email!3e",
-      "Address": "4th street",
-      "type": "owner"
-    }
+    "phone": "9482424",
+    "email": "invalid@email!3e",
+    "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalOwnersAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalOwnersAddressBook.json
@@ -1,74 +1,60 @@
 {
   "_comment": "AddressBook save file which contains the same Owner values as in TypicalOwners#getTypicalAddressBook()",
   "entities" : [ {
+    "type": "owner",
     "id": 1,
     "name" : "Alice Pauline",
-    "tagged" : [ "friends" ],
-    "propertyDict": {
-      "Email": "alice@example.com",
-      "Address": "123, Jurong West Ave 6, #08-111",
-      "Phone": "94351253",
-      "type": "owner"
-    }
-  }, {
-    "id": 2,
-    "name" : "Benson Meier",
-    "tagged" : [ "owesMoney", "friends" ],
-    "propertyDict": {
-      "Phone": "98765432",
-      "Email": "johnd@example.com",
-      "Address": "311, Clementi Ave 2, #02-25",
-      "type": "owner"
-    }
-  }, {
-    "id": 3,
-    "name" : "Carl Kurz",
-    "tagged" : [ ],
-    "propertyDict": {
-      "Phone": "95352563",
-      "Email": "heinz@example.com",
-      "Address": "wall street",
-      "type": "owner"
-    }
-  }, {
-    "id": 4,
-    "name" : "Daniel Meier",
-    "propertyDict": {
-      "type": "owner",
-      "Phone": "87652533",
-      "Email": "cornelia@example.com",
-      "Address": "10th street"
-    },
+    "phone" : "94351253",
+    "email" : "alice@example.com",
+    "address" : "123, Jurong West Ave 6, #08-111",
     "tagged" : [ "friends" ]
   }, {
+    "type": "owner",
+    "id": 2,
+    "name" : "Benson Meier",
+    "phone" : "98765432",
+    "email" : "johnd@example.com",
+    "address" : "311, Clementi Ave 2, #02-25",
+    "tagged" : [ "owesMoney", "friends" ]
+  }, {
+    "type": "owner",
+    "id": 3,
+    "name" : "Carl Kurz",
+    "phone" : "95352563",
+    "email" : "heinz@example.com",
+    "address" : "wall street",
+    "tagged" : [ ]
+  }, {
+    "type": "owner",
+    "id": 4,
+    "name" : "Daniel Meier",
+    "phone" : "87652533",
+    "email" : "cornelia@example.com",
+    "address" : "10th street",
+    "tagged" : [ "friends" ]
+  }, {
+    "type": "owner",
     "id": 5,
     "name" : "Elle Meyer",
-    "propertyDict": {
-      "type": "owner",
-      "Phone": "9482224",
-      "Email": "werner@example.com",
-      "Address": "michegan ave"
-    },
+    "phone" : "9482224",
+    "email" : "werner@example.com",
+    "address" : "michegan ave",
     "tagged" : [ ]
   }, {
+    "type": "owner",
     "id": 6,
     "name" : "Fiona Kunz",
-    "propertyDict": {
-      "type": "owner",
-      "Phone": "9482427",
-      "Email": "lydia@example.com",
-      "Address": "little tokyo"
-    },
+    "phone" : "9482427",
+    "email" : "lydia@example.com",
+    "address" : "little tokyo",
     "tagged" : [ ]
   }, {
+    "type": "owner",
     "id": 7,
     "name" : "George Best",
-    "propertyDict": {
-      "type": "owner",
-      "Phone": "9482442",
-      "Email": "anna@example.com",
-      "Address": "4th street"
-    },
+    "phone" : "9482442",
+    "email" : "anna@example.com",
+    "address" : "4th street",
     "tagged" : [ ]
   } ]
 }

--- a/src/test/java/dog/pawbook/storage/JsonAdaptedOwnerTest.java
+++ b/src/test/java/dog/pawbook/storage/JsonAdaptedOwnerTest.java
@@ -1,28 +1,25 @@
 package dog.pawbook.storage;
 
-import static dog.pawbook.storage.JsonAdaptedEntity.MISSING_FIELD_MESSAGE_FORMAT;
+import static dog.pawbook.storage.JsonAdaptedOwner.MISSING_FIELD_MESSAGE_FORMAT;
 import static dog.pawbook.testutil.Assert.assertThrows;
 import static dog.pawbook.testutil.TypicalOwners.BENSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import dog.pawbook.commons.exceptions.IllegalValueException;
-import dog.pawbook.model.managedentity.Entity;
 import dog.pawbook.model.managedentity.Name;
 import dog.pawbook.model.managedentity.owner.Address;
 import dog.pawbook.model.managedentity.owner.Email;
+import dog.pawbook.model.managedentity.owner.Owner;
 import dog.pawbook.model.managedentity.owner.Phone;
 import javafx.util.Pair;
 
-public class JsonAdaptedEntityOwnerTest {
+public class JsonAdaptedOwnerTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
@@ -37,83 +34,74 @@ public class JsonAdaptedEntityOwnerTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
-    private static final Map<String, String> otherPropertiesDict = new HashMap<>();
-
-    @BeforeEach
-    private void init() {
-        otherPropertiesDict.put("type", "owner");
-        otherPropertiesDict.put(Phone.class.getSimpleName(), VALID_PHONE);
-        otherPropertiesDict.put(Email.class.getSimpleName(), VALID_EMAIL);
-        otherPropertiesDict.put(Address.class.getSimpleName(), VALID_ADDRESS);
-    }
 
     @Test
     public void toModelType_validOwnerDetails_returnsOwner() throws Exception {
-        Pair<Integer, Entity> original = new Pair<>(BENSON_ID, BENSON);
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(original);
+        Pair<Integer, Owner> original = new Pair<>(BENSON_ID, BENSON);
+        JsonAdaptedOwner owner = new JsonAdaptedOwner(original);
         assertEquals(original, owner.toModelType());
     }
 
-    // todo: invalidID
-
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, INVALID_NAME, VALID_TAGS, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, owner::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, null, VALID_TAGS, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, owner::toModelType);
     }
 
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
-        otherPropertiesDict.put(Phone.class.getSimpleName(), INVALID_PHONE);
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, VALID_NAME, VALID_TAGS, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, owner::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        otherPropertiesDict.put(Phone.class.getSimpleName(), null);
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, VALID_NAME, VALID_TAGS, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, owner::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
-        otherPropertiesDict.put(Email.class.getSimpleName(), INVALID_EMAIL);
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, VALID_NAME, VALID_TAGS, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, owner::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        otherPropertiesDict.put(Email.class.getSimpleName(), null);
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, VALID_NAME, VALID_TAGS, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, owner::toModelType);
     }
 
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
-        otherPropertiesDict.put(Address.class.getSimpleName(), INVALID_ADDRESS);
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, VALID_NAME, VALID_TAGS, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, owner::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        otherPropertiesDict.put(Address.class.getSimpleName(), null);
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, VALID_NAME, VALID_TAGS, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, owner::toModelType);
     }
@@ -122,7 +110,8 @@ public class JsonAdaptedEntityOwnerTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedEntity owner = new JsonAdaptedEntity(BENSON_ID, VALID_NAME, invalidTags, otherPropertiesDict);
+        JsonAdaptedOwner owner =
+                new JsonAdaptedOwner(BENSON_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
         assertThrows(IllegalValueException.class, owner::toModelType);
     }
 


### PR DESCRIPTION
Previously during the major refactoring JsonAdaptedEntity was fixed in a way that was not sustainable nor easily extendable. This lead to several issues like not being able to easily store additional attributes of downstream Entity classes if they don't convert to and fro strings easily. Thus there is a need to fix that and also reduce the clutter that was originally in this particular file.

There is a change in file format and also the filename, so it should not cause any issues on local setups. The file format is much closer to the original one and no longer has deep nesting.

Closes #143 