### PR TITLE
Replace owner and dog string literals

### DIFF
--- a/src/main/java/dog/pawbook/logic/commands/AddCommand.java
+++ b/src/main/java/dog/pawbook/logic/commands/AddCommand.java
@@ -14,18 +14,20 @@ import static java.util.Objects.requireNonNull;
 import dog.pawbook.logic.commands.exceptions.CommandException;
 import dog.pawbook.model.Model;
 import dog.pawbook.model.managedentity.Entity;
+import dog.pawbook.model.managedentity.dog.Dog;
+import dog.pawbook.model.managedentity.owner.Owner;
 
 public abstract class AddCommand<T extends Entity> extends Command {
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a owner/dog/program to the address book. "
-            + "Example for Owner: " + COMMAND_WORD + " " + "owner" + " "
+            + "Example for Owner: " + COMMAND_WORD + " " + Owner.ENTITY_WORD + " "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example for Dog: " + COMMAND_WORD + " " + "dog" + " "
+            + "Example for Dog: " + COMMAND_WORD + " " + Dog.ENTITY_WORD + " "
             + PREFIX_NAME + "NAME "
             + PREFIX_BREED + "BREED "
             + PREFIX_DATEOFBIRTH + "DATE OF BIRTH "

--- a/src/main/java/dog/pawbook/logic/commands/AddDogCommand.java
+++ b/src/main/java/dog/pawbook/logic/commands/AddDogCommand.java
@@ -6,6 +6,7 @@ import static dog.pawbook.logic.parser.CliSyntax.PREFIX_NAME;
 import static dog.pawbook.logic.parser.CliSyntax.PREFIX_OWNERID;
 import static dog.pawbook.logic.parser.CliSyntax.PREFIX_SEX;
 import static dog.pawbook.logic.parser.CliSyntax.PREFIX_TAG;
+import static dog.pawbook.model.managedentity.dog.Dog.ENTITY_WORD;
 
 import dog.pawbook.model.managedentity.dog.Dog;
 
@@ -13,8 +14,6 @@ import dog.pawbook.model.managedentity.dog.Dog;
  * Adds a dog to the address book.
  */
 public class AddDogCommand extends AddCommand<Dog> {
-
-    public static final String ENTITY_WORD = "dog";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds dog to the address book. "
             + "Parameters: "
@@ -34,7 +33,7 @@ public class AddDogCommand extends AddCommand<Dog> {
             + PREFIX_TAG + "active";
 
     public static final String MESSAGE_SUCCESS = String.format(MESSAGE_SUCCESS_FORMAT, ENTITY_WORD);
-    public static final String MESSAGE_DUPLICATE_DOG = "This dog already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_DOG = "This " + ENTITY_WORD + " already exists";
 
     /**
      * Creates an AddCommand to add the specified {@code Dog}

--- a/src/main/java/dog/pawbook/logic/commands/AddOwnerCommand.java
+++ b/src/main/java/dog/pawbook/logic/commands/AddOwnerCommand.java
@@ -5,6 +5,7 @@ import static dog.pawbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static dog.pawbook.logic.parser.CliSyntax.PREFIX_NAME;
 import static dog.pawbook.logic.parser.CliSyntax.PREFIX_PHONE;
 import static dog.pawbook.logic.parser.CliSyntax.PREFIX_TAG;
+import static dog.pawbook.model.managedentity.owner.Owner.ENTITY_WORD;
 
 import dog.pawbook.model.managedentity.owner.Owner;
 
@@ -19,7 +20,7 @@ public class AddOwnerCommand extends AddCommand<Owner> {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " " + Owner.ENTITY_WORD + " "
+            + "Example: " + COMMAND_WORD + " " + ENTITY_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
@@ -27,8 +28,8 @@ public class AddOwnerCommand extends AddCommand<Owner> {
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 
-    public static final String MESSAGE_SUCCESS = String.format(MESSAGE_SUCCESS_FORMAT, Owner.ENTITY_WORD);
-    public static final String MESSAGE_DUPLICATE_OWNER = "This owner already exists in the address book";
+    public static final String MESSAGE_SUCCESS = String.format(MESSAGE_SUCCESS_FORMAT, ENTITY_WORD);
+    public static final String MESSAGE_DUPLICATE_OWNER = "This " + ENTITY_WORD + " already exists";
 
     /**
      * Creates an AddCommand to add the specified {@code Owner}

--- a/src/main/java/dog/pawbook/logic/commands/DeleteCommand.java
+++ b/src/main/java/dog/pawbook/logic/commands/DeleteCommand.java
@@ -1,15 +1,17 @@
 package dog.pawbook.logic.commands;
 
 import dog.pawbook.commons.core.index.Index;
+import dog.pawbook.model.managedentity.dog.Dog;
+import dog.pawbook.model.managedentity.owner.Owner;
 
 public abstract class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the owner/dog/program identified by the index number used in the displayed entity list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " owner 1\n"
-            + "Example: " + COMMAND_WORD + " dog 1";
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD + ": Deletes the owner/dog/program identified by ID.\n"
+            + "Parameters: ID (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " " + Owner.ENTITY_WORD + " 1\n"
+            + "Example: " + COMMAND_WORD + " " + Dog.ENTITY_WORD + " 2";
 
     public static final String MESSAGE_DELETE_SUCCESS_FORMAT = "Deleted %s: ";
 

--- a/src/main/java/dog/pawbook/logic/commands/DeleteDogCommand.java
+++ b/src/main/java/dog/pawbook/logic/commands/DeleteDogCommand.java
@@ -1,5 +1,6 @@
 package dog.pawbook.logic.commands;
 
+import static dog.pawbook.model.managedentity.dog.Dog.ENTITY_WORD;
 import static java.util.Objects.requireNonNull;
 
 import java.util.NoSuchElementException;
@@ -16,12 +17,10 @@ import dog.pawbook.model.managedentity.dog.Dog;
  */
 public class DeleteDogCommand extends DeleteCommand {
 
-    public static final String ENTITY_WORD = "dog";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the dog identified by the index number used in the displayed entity list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " dog 1";
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD + ": Deletes the dog identified by ID.\n"
+            + "Parameters: ID (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " " + ENTITY_WORD + " 1";
 
     public static final String MESSAGE_SUCCESS = String.format(MESSAGE_DELETE_SUCCESS_FORMAT, ENTITY_WORD);
 

--- a/src/main/java/dog/pawbook/logic/commands/DeleteOwnerCommand.java
+++ b/src/main/java/dog/pawbook/logic/commands/DeleteOwnerCommand.java
@@ -1,5 +1,6 @@
 package dog.pawbook.logic.commands;
 
+import static dog.pawbook.model.managedentity.owner.Owner.ENTITY_WORD;
 import static java.util.Objects.requireNonNull;
 
 import java.util.NoSuchElementException;
@@ -16,12 +17,10 @@ import dog.pawbook.model.managedentity.owner.Owner;
  */
 public class DeleteOwnerCommand extends DeleteCommand {
 
-    public static final String ENTITY_WORD = "owner";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the owner identified by the index number used in the displayed entity list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " owner 1";
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD + ": Deletes the owner identified by ID.\n"
+            + "Parameters: ID (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " " + ENTITY_WORD + " 1";
 
     public static final String MESSAGE_SUCCESS = String.format(MESSAGE_DELETE_SUCCESS_FORMAT, ENTITY_WORD);
 

--- a/src/main/java/dog/pawbook/logic/parser/PawbookParser.java
+++ b/src/main/java/dog/pawbook/logic/parser/PawbookParser.java
@@ -9,15 +9,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import dog.pawbook.logic.commands.AddCommand;
-import dog.pawbook.logic.commands.AddDogCommand;
 import dog.pawbook.logic.commands.Command;
 import dog.pawbook.logic.commands.DeleteCommand;
-import dog.pawbook.logic.commands.DeleteDogCommand;
-import dog.pawbook.logic.commands.DeleteOwnerCommand;
 import dog.pawbook.logic.commands.ExitCommand;
 import dog.pawbook.logic.commands.HelpCommand;
 import dog.pawbook.logic.parser.exceptions.ParseException;
 import dog.pawbook.model.managedentity.Entity;
+import dog.pawbook.model.managedentity.dog.Dog;
 import dog.pawbook.model.managedentity.owner.Owner;
 
 /**
@@ -69,6 +67,9 @@ public class PawbookParser {
 
     }
 
+    /**
+     * Generate an AddCommand according to type of entity.
+     */
     private AddCommand<? extends Entity> generateAddCommand(String entityType, String arguments) throws ParseException {
         if (entityType.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
@@ -77,7 +78,7 @@ public class PawbookParser {
         switch (entityType) {
         case Owner.ENTITY_WORD:
             return new AddOwnerCommandParser().parse(arguments);
-        case AddDogCommand.ENTITY_WORD:
+        case Dog.ENTITY_WORD:
             return new AddDogCommandParser().parse(arguments);
 
         default:
@@ -85,15 +86,18 @@ public class PawbookParser {
         }
     }
 
+    /**
+     * Generate a DeleteCommand according to type of entity.
+     */
     private DeleteCommand generateDeleteCommand(String entityType, String arguments) throws ParseException {
         if (entityType.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
         switch (entityType) {
-        case DeleteOwnerCommand.ENTITY_WORD:
+        case Owner.ENTITY_WORD:
             return new DeleteOwnerCommandParser().parse(arguments);
-        case DeleteDogCommand.ENTITY_WORD:
+        case Dog.ENTITY_WORD:
             return new DeleteDogCommandParser().parse(arguments);
 
         default:

--- a/src/main/java/dog/pawbook/storage/JsonAdaptedDog.java
+++ b/src/main/java/dog/pawbook/storage/JsonAdaptedDog.java
@@ -17,7 +17,7 @@ import dog.pawbook.model.managedentity.dog.Sex;
 import dog.pawbook.model.managedentity.tag.Tag;
 import javafx.util.Pair;
 
-@JsonTypeName("dog")
+@JsonTypeName(Dog.ENTITY_WORD)
 public class JsonAdaptedDog extends JsonAdaptedEntity {
     private final String breed;
     private final String dob;

--- a/src/main/java/dog/pawbook/storage/JsonAdaptedEntity.java
+++ b/src/main/java/dog/pawbook/storage/JsonAdaptedEntity.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dog.pawbook.commons.exceptions.IllegalValueException;
 import dog.pawbook.model.managedentity.Entity;
 import dog.pawbook.model.managedentity.Name;
+import dog.pawbook.model.managedentity.dog.Dog;
+import dog.pawbook.model.managedentity.owner.Owner;
 import dog.pawbook.model.managedentity.tag.Tag;
 import javafx.util.Pair;
 
@@ -24,8 +26,8 @@ import javafx.util.Pair;
         use = JsonTypeInfo.Id.NAME,
         property = "type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = JsonAdaptedOwner.class, name = "owner"),
-        @JsonSubTypes.Type(value = JsonAdaptedDog.class, name = "dog")
+        @JsonSubTypes.Type(value = JsonAdaptedOwner.class, name = Owner.ENTITY_WORD),
+        @JsonSubTypes.Type(value = JsonAdaptedDog.class, name = Dog.ENTITY_WORD)
 })
 abstract class JsonAdaptedEntity {
 

--- a/src/main/java/dog/pawbook/storage/JsonAdaptedOwner.java
+++ b/src/main/java/dog/pawbook/storage/JsonAdaptedOwner.java
@@ -17,7 +17,7 @@ import dog.pawbook.model.managedentity.owner.Phone;
 import dog.pawbook.model.managedentity.tag.Tag;
 import javafx.util.Pair;
 
-@JsonTypeName("owner")
+@JsonTypeName(Owner.ENTITY_WORD)
 public class JsonAdaptedOwner extends JsonAdaptedEntity {
     private final String phone;
     private final String email;

--- a/src/test/java/dog/pawbook/logic/parser/PawbookParserTest.java
+++ b/src/test/java/dog/pawbook/logic/parser/PawbookParserTest.java
@@ -45,7 +45,7 @@ public class PawbookParserTest {
     @Test
     public void parseCommand_deleteOwner() throws Exception {
         DeleteOwnerCommand command = (DeleteOwnerCommand) parser.parseCommand(
-                DeleteOwnerCommand.COMMAND_WORD + " " + DeleteOwnerCommand.ENTITY_WORD + " " + INDEX_FIRST_OWNER
+                DeleteOwnerCommand.COMMAND_WORD + " " + Owner.ENTITY_WORD + " " + INDEX_FIRST_OWNER
                         .getOneBased());
         assertEquals(new DeleteOwnerCommand(INDEX_SECOND_OWNER), command);
     }
@@ -53,7 +53,7 @@ public class PawbookParserTest {
     @Test
     public void parseCommand_deleteDog() throws Exception {
         DeleteDogCommand command = (DeleteDogCommand) parser.parseCommand(
-                DeleteDogCommand.COMMAND_WORD + " " + DeleteDogCommand.ENTITY_WORD + " " + INDEX_FIRST_OWNER
+                DeleteDogCommand.COMMAND_WORD + " " + Dog.ENTITY_WORD + " " + INDEX_FIRST_OWNER
                         .getOneBased());
         assertEquals(new DeleteDogCommand(INDEX_SECOND_OWNER), command);
     }


### PR DESCRIPTION
There are a lot of string literals of owners and dogs in the code, alongside the same constant being defined multiple times. This is less than ideal and it will be better to define it only in one place and use it throughout the code.

Not sure where else in the test cases can this be extended to. But now the standard is available.

Closes #151 