### PR TITLE
Move UniqueEntityList one level higher

### DIFF
--- a/src/main/java/dog/pawbook/model/AddressBook.java
+++ b/src/main/java/dog/pawbook/model/AddressBook.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import dog.pawbook.model.managedentity.Entity;
-import dog.pawbook.model.managedentity.owner.UniqueEntityList;
+import dog.pawbook.model.managedentity.UniqueEntityList;
 import javafx.collections.ObservableList;
 import javafx.util.Pair;
 

--- a/src/main/java/dog/pawbook/model/managedentity/UniqueEntityList.java
+++ b/src/main/java/dog/pawbook/model/managedentity/UniqueEntityList.java
@@ -1,4 +1,4 @@
-package dog.pawbook.model.managedentity.owner;
+package dog.pawbook.model.managedentity;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -6,7 +6,6 @@ import static java.util.stream.Collectors.toList;
 import java.util.Iterator;
 import java.util.List;
 
-import dog.pawbook.model.managedentity.Entity;
 import dog.pawbook.model.managedentity.exceptions.DuplicateEntityException;
 import dog.pawbook.model.managedentity.exceptions.EntityNotFoundException;
 import javafx.collections.FXCollections;

--- a/src/test/java/dog/pawbook/model/managedentity/owner/UniqueEntityListTest.java
+++ b/src/test/java/dog/pawbook/model/managedentity/owner/UniqueEntityListTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import dog.pawbook.model.managedentity.Entity;
+import dog.pawbook.model.managedentity.UniqueEntityList;
 import dog.pawbook.model.managedentity.exceptions.DuplicateEntityException;
 import dog.pawbook.model.managedentity.exceptions.EntityNotFoundException;
 import javafx.util.Pair;


### PR DESCRIPTION
UniqueEntityList is no longer UniqueOwnerList, and therefore should not be parked under the Owner package.