### PR TITLE
Ensure that all references to other Entities are valid upon import and edit

### DIFF
--- a/src/main/java/dog/pawbook/model/AddressBook.java
+++ b/src/main/java/dog/pawbook/model/AddressBook.java
@@ -11,7 +11,6 @@ import javafx.util.Pair;
 
 /**
  * Wraps all data at the address-book level
- * Duplicates are not allowed (by .isSameOwner comparison)
  */
 public class AddressBook implements ReadOnlyAddressBook {
 
@@ -31,7 +30,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public AddressBook() {}
 
     /**
-     * Creates an AddressBook using the Owners in the {@code toBeCopied}
+     * Creates an AddressBook using the Entities in the {@code toBeCopied}
      */
     public AddressBook(ReadOnlyAddressBook toBeCopied) {
         this();
@@ -41,8 +40,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     //// list overwrite operations
 
     /**
-     * Replaces the contents of the owner list with {@code owners}.
-     * {@code owners} must not contain duplicate owners.
+     * Replaces the contents of the entity list with {@code owners}.
+     * {@code entities} must not contain duplicate entities or invalid reference IDs.
      */
     public void setEntities(List<Pair<Integer, Entity>> entities) {
         this.entities.setEntities(entities);
@@ -115,6 +114,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public Entity getEntity(int targetID) {
         return entities.get(targetID);
+    }
+
+    /**
+     * Validate all links to other IDs from all entities.
+     */
+    public boolean validateReferences() {
+        return entities.validateReferences();
     }
 
     //// util methods

--- a/src/main/java/dog/pawbook/model/managedentity/exceptions/BrokenReferencesException.java
+++ b/src/main/java/dog/pawbook/model/managedentity/exceptions/BrokenReferencesException.java
@@ -1,0 +1,11 @@
+package dog.pawbook.model.managedentity.exceptions;
+
+/**
+ * Signals that the operation will results in broken mutual references among the stored entities. Every entities' stored
+ * IDs of others has to be maintained properly.
+ */
+public class BrokenReferencesException extends RuntimeException {
+    public BrokenReferencesException() {
+        super("Operation will results in broken references among entities.");
+    }
+}

--- a/src/main/java/dog/pawbook/model/managedentity/exceptions/DuplicateEntityException.java
+++ b/src/main/java/dog/pawbook/model/managedentity/exceptions/DuplicateEntityException.java
@@ -1,8 +1,7 @@
 package dog.pawbook.model.managedentity.exceptions;
 
 /**
- * Signals that the operation will result in duplicate Owners (Owners are considered duplicates if they have the same
- * identity).
+ * Signals that the operation will result in duplicate Entities.
  */
 public class DuplicateEntityException extends RuntimeException {
     public DuplicateEntityException() {

--- a/src/main/java/dog/pawbook/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/dog/pawbook/storage/JsonSerializableAddressBook.java
@@ -24,6 +24,7 @@ import javafx.util.Pair;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_OWNER = "Entities list contains duplicate entit(y|ies).";
+    public static final String MESSAGE_INVALID_REFERENCE_IDS = "Entities refer to broken IDs";
 
     private final List<JsonAdaptedEntity> entities = new ArrayList<>();
 
@@ -77,6 +78,10 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_OWNER);
             }
             addressBook.addEntityWithId(idEntityPair.getValue(), idEntityPair.getKey());
+        }
+
+        if (!addressBook.validateReferences()) {
+            throw new IllegalValueException(MESSAGE_INVALID_REFERENCE_IDS);
         }
         return addressBook;
     }

--- a/src/test/java/dog/pawbook/logic/commands/DeleteDogCommandTest.java
+++ b/src/test/java/dog/pawbook/logic/commands/DeleteDogCommandTest.java
@@ -2,10 +2,9 @@ package dog.pawbook.logic.commands;
 
 import static dog.pawbook.logic.commands.CommandTestUtil.assertCommandFailure;
 import static dog.pawbook.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static dog.pawbook.logic.commands.CommandTestUtil.showDogAtIndex;
 import static dog.pawbook.testutil.TypicalDogs.getTypicalAddressBook;
-import static dog.pawbook.testutil.TypicalIndexes.INDEX_FIRST_DOG;
 import static dog.pawbook.testutil.TypicalIndexes.INDEX_SECOND_DOG;
+import static dog.pawbook.testutil.TypicalIndexes.INDEX_THIRD_DOG;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,7 +31,7 @@ public class DeleteDogCommandTest {
 
     @Test
     public void execute_validIdUnfilteredList_success() {
-        Pair<Integer, Entity> pair = model.getFilteredEntityList().get(0);
+        Pair<Integer, Entity> pair = model.getFilteredEntityList().get(1);
         DeleteDogCommand deleteDogCommand = new DeleteDogCommand(Index.fromZeroBased(pair.getKey()));
 
         String expectedMessage = DeleteDogCommand.MESSAGE_SUCCESS + pair.getValue();
@@ -53,44 +52,15 @@ public class DeleteDogCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_success() {
-        showDogAtIndex(model, INDEX_FIRST_DOG);
-
-        Entity entityToDelete = model.getFilteredEntityList().get(0).getValue();
-        DeleteDogCommand deleteDogCommand = new DeleteDogCommand(INDEX_FIRST_DOG);
-
-        String expectedMessage = DeleteDogCommand.MESSAGE_SUCCESS + entityToDelete;
-
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.deleteEntity(model.getFilteredEntityList().get(0).getKey());
-        showNoDog(expectedModel);
-
-        assertCommandSuccess(deleteDogCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showDogAtIndex(model, INDEX_FIRST_DOG);
-
-        Index outOfBoundIndex = INDEX_SECOND_DOG;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getEntityList().size());
-
-        DeleteDogCommand deleteDogCommand = new DeleteDogCommand(outOfBoundIndex);
-
-        assertCommandFailure(deleteDogCommand, model, Messages.MESSAGE_INVALID_DOG_DISPLAYED_ID);
-    }
-
-    @Test
     public void equals() {
-        DeleteDogCommand deleteFirstCommand = new DeleteDogCommand(INDEX_FIRST_DOG);
-        DeleteDogCommand deleteSecondCommand = new DeleteDogCommand(INDEX_SECOND_DOG);
+        DeleteDogCommand deleteFirstCommand = new DeleteDogCommand(INDEX_SECOND_DOG);
+        DeleteDogCommand deleteSecondCommand = new DeleteDogCommand(INDEX_THIRD_DOG);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteDogCommand deleteFirstCommandCopy = new DeleteDogCommand(INDEX_FIRST_DOG);
+        DeleteDogCommand deleteFirstCommandCopy = new DeleteDogCommand(INDEX_SECOND_DOG);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/dog/pawbook/model/managedentity/dog/DogTest.java
+++ b/src/test/java/dog/pawbook/model/managedentity/dog/DogTest.java
@@ -9,6 +9,7 @@ import static dog.pawbook.testutil.Assert.assertThrows;
 import static dog.pawbook.testutil.TypicalDogs.APPLE;
 import static dog.pawbook.testutil.TypicalDogs.ASHER;
 import static dog.pawbook.testutil.TypicalDogs.BUBBLES;
+import static dog.pawbook.testutil.TypicalDogs.DOG_OWNER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -55,8 +56,8 @@ public class DogTest {
 
     @Test
     public void getOwnerId() {
-        assertEquals(APPLE.getOwnerId(), 1);
-        assertEquals(BUBBLES.getOwnerId(), 2);
+        assertEquals(APPLE.getOwnerId(), DOG_OWNER_ID);
+        assertEquals(BUBBLES.getOwnerId(), DOG_OWNER_ID);
     }
 
     @Test

--- a/src/test/java/dog/pawbook/model/managedentity/owner/UniqueEntityListTest.java
+++ b/src/test/java/dog/pawbook/model/managedentity/owner/UniqueEntityListTest.java
@@ -25,8 +25,8 @@ public class UniqueEntityListTest {
     private final UniqueEntityList uniqueEntityList = new UniqueEntityList();
 
     @Test
-    public void contains_nullOwner_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueEntityList.contains(null));
+    public void contains_nullEntity_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueEntityList.contains((Entity) null));
     }
 
     @Test
@@ -129,4 +129,9 @@ public class UniqueEntityListTest {
                 .asUnmodifiableObservableList()
                 .remove(0));
     }
+
+    // todo: set the list to contain an entity something that contains references to other entities that does not exist
+    // todo: set the list to contain two entities that should both store references to each but did not
+    // todo: set the list to contain entities with duplicate IDs
+    // todo: set the list to have similar entities of different types
 }

--- a/src/test/java/dog/pawbook/testutil/TypicalDogs.java
+++ b/src/test/java/dog/pawbook/testutil/TypicalDogs.java
@@ -15,38 +15,47 @@ import static dog.pawbook.logic.commands.CommandTestUtil.VALID_TAG_QUIET;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import dog.pawbook.model.AddressBook;
 import dog.pawbook.model.managedentity.dog.Dog;
+import dog.pawbook.model.managedentity.owner.Owner;
 
 /**
  * A utility class containing a list of {@code Dog} objects to be used in tests.
  */
 public class TypicalDogs {
+    public static final int DOG_OWNER_ID = 1;
+
+    public static final Owner DOG_OWNER = new OwnerBuilder().withName("Alice Pauline")
+            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+            .withPhone("94351253")
+            .withTags("friends").build();
 
     public static final Dog APPLE = new DogBuilder().withName("Apple")
             .withBreed("Golden Retriever").withDateOfBirth("11-2-2020")
             .withSex("female").withOwnerID(1).withTags("friendly").build();
     public static final Dog BUBBLES = new DogBuilder().withName("Bubbles")
-            .withBreed("Bulldog").withDateOfBirth("1-1-2021").withSex("female").withOwnerID(2)
+            .withBreed("Bulldog").withDateOfBirth("1-1-2021").withSex("female").withOwnerID(DOG_OWNER_ID)
             .withTags("cheerful").build();
     public static final Dog CARSON = new DogBuilder().withName("Carson").withSex("male")
-            .withDateOfBirth("2-2-2019").withBreed("male").withOwnerID(3).build();
-    public static final Dog DUKE = new DogBuilder().withName("Duke").withSex("male")
-            .withDateOfBirth("4-5-2020").withBreed("German Shepherd").withTags("quiet").build();
+            .withDateOfBirth("2-2-2019").withBreed("male").withOwnerID(DOG_OWNER_ID).build();
+    public static final Dog DUKE = new DogBuilder().withName("Duke").withSex("male").withDateOfBirth("4-5-2020")
+            .withBreed("German Shepherd").withOwnerID(DOG_OWNER_ID).withTags("quiet").build();
     public static final Dog ELSA = new DogBuilder().withName("Elsa").withSex("female")
-            .withDateOfBirth("2-2-2020").withBreed("Poodle").withOwnerID(4).build();
+            .withDateOfBirth("2-2-2020").withBreed("Poodle").withOwnerID(DOG_OWNER_ID).build();
     public static final Dog FLORA = new DogBuilder().withName("Flora").withSex("female")
-            .withDateOfBirth("21-8-2018").withBreed("Australian Shepherd").withOwnerID(5).build();
+            .withDateOfBirth("21-8-2018").withBreed("Australian Shepherd").withOwnerID(DOG_OWNER_ID).build();
     public static final Dog GENIE = new DogBuilder().withName("Genie").withSex("male")
-            .withDateOfBirth("29-5-2020").withBreed("Husky").withOwnerID(6).build();
+            .withDateOfBirth("29-5-2020").withBreed("Husky").withOwnerID(DOG_OWNER_ID).build();
 
     // Manually added
     public static final Dog HOOK = new DogBuilder().withName("Hook").withSex("male")
-            .withDateOfBirth("13-7-2019").withBreed("Chihuahua").withOwnerID(7).build();
+            .withDateOfBirth("13-7-2019").withBreed("Chihuahua").withOwnerID(DOG_OWNER_ID).build();
     public static final Dog INK = new DogBuilder().withName("Ink").withSex("male")
-            .withDateOfBirth("9-9-2020").withBreed("Rottweiler").withOwnerID(8).build();
+            .withDateOfBirth("9-9-2020").withBreed("Rottweiler").withOwnerID(DOG_OWNER_ID).build();
 
     // Manually added - Dog's details found in {@code CommandTestUtil}
     public static final Dog ASHER = new DogBuilder().withName(VALID_NAME_ASHER).withSex(VALID_SEX_ASHER)
@@ -65,9 +74,14 @@ public class TypicalDogs {
      */
     public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();
+        ab.addEntityWithId(DOG_OWNER, 1);
+        Set<Integer> ids = new HashSet<>(DOG_OWNER.getDogIdSet());
         for (Dog dog : getTypicalDogs()) {
-            ab.addEntity(dog);
+            int id = ab.addEntity(dog);
+            ids.add(id);
         }
+        ab.setEntity(1, new Owner(DOG_OWNER.getName(), DOG_OWNER.getPhone(), DOG_OWNER.getEmail(),
+                DOG_OWNER.getAddress(), DOG_OWNER.getTags(), ids));
         return ab;
     }
 

--- a/src/test/java/dog/pawbook/testutil/TypicalOwners.java
+++ b/src/test/java/dog/pawbook/testutil/TypicalOwners.java
@@ -30,7 +30,7 @@ public class TypicalOwners {
     public static final Owner BENSON = new OwnerBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").withDogs(100, 200).build();
+            .withTags("owesMoney", "friends").build();
     public static final Owner CARL = new OwnerBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Owner DANIEL = new OwnerBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
This PR introduces more sanity checks to ensure that the state of the `UniqueEntityList` stays consistent and valid. For example for any dog, the referenced owner ID should point to a valid Owner object whose list of dog IDs also contain the ID of the very same dog. This PR however does not enforce these rules upon adding or deleting of entities as enforcing for those will result in a chicken-and-egg problem. It is necessary to make sure that users of those methods also update the ID references through tests instead.