### PR TITLE
Have a generic base class for all command parsers that deal with prefixed arguments

### DIFF
--- a/src/main/java/dog/pawbook/logic/parser/AddDogCommandParser.java
+++ b/src/main/java/dog/pawbook/logic/parser/AddDogCommandParser.java
@@ -22,7 +22,7 @@ import dog.pawbook.model.managedentity.tag.Tag;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddDogCommandParser extends AddCommandParser<AddDogCommand> {
+public class AddDogCommandParser extends CommandWithPrefixParser<AddDogCommand> {
     private static final Prefix[] DOG_COMPULSORY_PREFIXES = {
         PREFIX_NAME, PREFIX_BREED, PREFIX_DATEOFBIRTH, PREFIX_OWNERID, PREFIX_SEX
     };

--- a/src/main/java/dog/pawbook/logic/parser/AddOwnerCommandParser.java
+++ b/src/main/java/dog/pawbook/logic/parser/AddOwnerCommandParser.java
@@ -21,7 +21,7 @@ import dog.pawbook.model.managedentity.tag.Tag;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddOwnerCommandParser extends AddCommandParser<AddOwnerCommand> {
+public class AddOwnerCommandParser extends CommandWithPrefixParser<AddOwnerCommand> {
     private static final Prefix[] OWNER_COMPULSORY_PREFIXES = {PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL};
     private static final Prefix[] OWNER_OPTIONAL_PREFIXES = {PREFIX_TAG};
     private static final Prefix[] OWNER_ALL_PREFIXES =

--- a/src/main/java/dog/pawbook/logic/parser/AddProgramCommandParser.java
+++ b/src/main/java/dog/pawbook/logic/parser/AddProgramCommandParser.java
@@ -17,7 +17,7 @@ import dog.pawbook.model.managedentity.tag.Tag;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddProgramCommandParser extends AddCommandParser<AddProgramCommand> {
+public class AddProgramCommandParser extends CommandWithPrefixParser<AddProgramCommand> {
     private static final Prefix[] PROGRAM_COMPULSORY_PREFIXES = {PREFIX_NAME, PREFIX_SESSION};
     private static final Prefix[] PROGRAM_OPTIONAL_PREFIXES = {PREFIX_TAG};
     private static final Prefix[] PROGRAM_ALL_PREFIXES =

--- a/src/main/java/dog/pawbook/logic/parser/CommandWithPrefixParser.java
+++ b/src/main/java/dog/pawbook/logic/parser/CommandWithPrefixParser.java
@@ -4,10 +4,10 @@ import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.stream.Stream;
 
-import dog.pawbook.logic.commands.AddCommand;
+import dog.pawbook.logic.commands.Command;
 import dog.pawbook.logic.parser.exceptions.ParseException;
 
-public abstract class AddCommandParser<T extends AddCommand> implements Parser<T> {
+public abstract class CommandWithPrefixParser<T extends Command> implements Parser<T> {
     /**
      * Returns an array containing all compulsory prefixes.
      */

--- a/src/main/java/dog/pawbook/logic/parser/EnrolCommandParser.java
+++ b/src/main/java/dog/pawbook/logic/parser/EnrolCommandParser.java
@@ -1,6 +1,5 @@
 package dog.pawbook.logic.parser;
 
-import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static dog.pawbook.logic.parser.CliSyntax.PREFIX_DOGID;
 import static dog.pawbook.logic.parser.CliSyntax.PREFIX_PROGRAMID;
 
@@ -9,7 +8,7 @@ import java.util.stream.Stream;
 import dog.pawbook.logic.commands.EnrolCommand;
 import dog.pawbook.logic.parser.exceptions.ParseException;
 
-public class EnrolCommandParser implements Parser<EnrolCommand> {
+public class EnrolCommandParser extends CommandWithPrefixParser<EnrolCommand> {
 
     private static final Prefix[] ENROL_COMPULSORY_PREFIXES = { PREFIX_DOGID, PREFIX_PROGRAMID };
     private static final Prefix[] ENROL_ALL_PREFIXES =
@@ -34,30 +33,6 @@ public class EnrolCommandParser implements Parser<EnrolCommand> {
      */
     protected String getUsageText() {
         return EnrolCommand.MESSAGE_USAGE;
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    protected final boolean areCompulsoryPrefixesPresent(ArgumentMultimap argumentMultimap) {
-        return Stream.of(getCompulsoryPrefixes()).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
-    /**
-     * Extracts all argument values tagged by the corresponding prefixes and guarantees that all compulsory arguments
-     * are supplied.
-     *
-     * @throws ParseException if the user input does not conform the expected format
-     */
-    protected final ArgumentMultimap extractArguments(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, getAllPrefixes());
-
-        if (!areCompulsoryPrefixesPresent(argMultimap) || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, getUsageText()));
-        }
-
-        return argMultimap;
     }
 
     /**


### PR DESCRIPTION
Commands like add and enrol both accept arguments with prefix appended in front, to avoid boilerplate codes, it is better to provide all of them with a base class that handles a lot of the repeated tasks.