### PR TITLE
Fix issue #289

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.controlsfx', name: 'controlsfx', version: '11.1.0'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'

--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -57,4 +57,4 @@ CommandBox -[hidden]left- ResultDisplay
 ResultDisplay -[hidden]left- StatusBarFooter
 
 MainWindow -[hidden]-|> UiPart
-@enduml
+

--- a/src/main/java/dog/pawbook/ui/CommandBox.java
+++ b/src/main/java/dog/pawbook/ui/CommandBox.java
@@ -1,10 +1,15 @@
 package dog.pawbook.ui;
 
+import org.controlsfx.control.textfield.AutoCompletionBinding;
+import org.controlsfx.control.textfield.TextFields;
+
 import dog.pawbook.logic.commands.CommandResult;
 import dog.pawbook.logic.commands.exceptions.CommandException;
 import dog.pawbook.logic.parser.exceptions.ParseException;
+import impl.org.controlsfx.skin.AutoCompletePopup;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 
 /**
@@ -18,7 +23,7 @@ public class CommandBox extends UiPart<Region> {
     private final CommandExecutor commandExecutor;
 
     @FXML
-    private AutoCompleteTextField commandTextField;
+    private TextField commandTextField;
 
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
@@ -27,8 +32,15 @@ public class CommandBox extends UiPart<Region> {
         super(FXML);
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
-        commandTextField.getEntries().addAll(CommandSuggestions.getSuggestions());
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        String[] commandSuggestions = CommandSuggestions.getSuggestions();
+        AutoCompletionBinding<String> autoCompletionBinding = TextFields.bindAutoCompletion(commandTextField,
+            commandSuggestions);
+        autoCompletionBinding.setVisibleRowCount(5);
+        autoCompletionBinding.setDelay(100);
+        AutoCompletePopup<String> popupAutoComplete = autoCompletionBinding.getAutoCompletionPopup();
+        popupAutoComplete.anchorLocation
+        popupAutoComplete.setId("popupAutoComplete"); // for styles in the css files
     }
 
     /**

--- a/src/main/java/dog/pawbook/ui/CommandBox.java
+++ b/src/main/java/dog/pawbook/ui/CommandBox.java
@@ -39,7 +39,6 @@ public class CommandBox extends UiPart<Region> {
         autoCompletionBinding.setVisibleRowCount(5);
         autoCompletionBinding.setDelay(100);
         AutoCompletePopup<String> popupAutoComplete = autoCompletionBinding.getAutoCompletionPopup();
-        popupAutoComplete.anchorLocation
         popupAutoComplete.setId("popupAutoComplete"); // for styles in the css files
     }
 

--- a/src/main/java/dog/pawbook/ui/CommandSuggestions.java
+++ b/src/main/java/dog/pawbook/ui/CommandSuggestions.java
@@ -1,25 +1,53 @@
 package dog.pawbook.ui;
 
-import java.util.Arrays;
-import java.util.List;
+import dog.pawbook.logic.commands.AddDogCommand;
+import dog.pawbook.logic.commands.AddOwnerCommand;
+import dog.pawbook.logic.commands.AddProgramCommand;
+import dog.pawbook.logic.commands.DeleteDogCommand;
+import dog.pawbook.logic.commands.DeleteOwnerCommand;
+import dog.pawbook.logic.commands.DeleteProgramCommand;
+import dog.pawbook.logic.commands.DropCommand;
+import dog.pawbook.logic.commands.EditDogCommand;
+import dog.pawbook.logic.commands.EditOwnerCommand;
+import dog.pawbook.logic.commands.EditProgramCommand;
+import dog.pawbook.logic.commands.EnrolCommand;
+import dog.pawbook.logic.commands.ExitCommand;
+import dog.pawbook.logic.commands.FindCommand;
+import dog.pawbook.logic.commands.HelpCommand;
+import dog.pawbook.logic.commands.ListCommand;
+import dog.pawbook.logic.commands.ScheduleCommand;
+import dog.pawbook.logic.commands.ViewCommand;
 
 /**
  * A class containing command keywords to be matched with for autocompletion.
  */
 public class CommandSuggestions {
-    private static List<String> suggestions = Arrays.asList(
-        "add dog", "add owner", "add program",
-        "delete dog", "delete owner", "delete program",
-        "edit dog", "edit owner", "edit program", "enrol", "drop", "find", "view", "schedule",
-        "list", "list dog", "list owner", "list program", "exit", "help"
-    );
 
-    public static List<String> getSuggestions() {
-        return suggestions;
+    public static String[] getSuggestions() {
+        return new String[] {
+            AddDogCommand.COMMAND_WORD + " dog",
+            AddOwnerCommand.COMMAND_WORD + " owner",
+            AddProgramCommand.COMMAND_WORD + " program",
+            DeleteDogCommand.COMMAND_WORD + " dog",
+            DeleteOwnerCommand.COMMAND_WORD + " owner",
+            DeleteProgramCommand.COMMAND_WORD + " program",
+            EditDogCommand.COMMAND_WORD + " dog",
+            EditOwnerCommand.COMMAND_WORD + " owner",
+            EditProgramCommand.COMMAND_WORD + " program",
+            ExitCommand.COMMAND_WORD,
+            HelpCommand.COMMAND_WORD,
+            FindCommand.COMMAND_WORD,
+            ViewCommand.COMMAND_WORD,
+            ScheduleCommand.COMMAND_WORD,
+            EnrolCommand.COMMAND_WORD,
+            DropCommand.COMMAND_WORD,
+            ListCommand.COMMAND_WORD,
+            ListCommand.COMMAND_WORD + " dog",
+            ListCommand.COMMAND_WORD + " owner",
+            ListCommand.COMMAND_WORD + " program",
+        };
     }
 
-    public static void addSuggestion(String suggestion) {
-        suggestions.add(suggestion);
-    }
+
 
 }

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import dog.pawbook.ui.AutoCompleteTextField?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.control.TextField?>
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
-  <AutoCompleteTextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here" />
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here" />
 </StackPane>

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -18,3 +18,18 @@
 .tooltip-text {
     -fx-text-fill: white;
 }
+
+#popupAutoComplete .list-cell {
+    -fx-background-color: $background;
+    -fx-text-fill: $foreground;
+    -fx-font-size: 15px;
+}
+
+#popupAutoComplete .list-cell:selected {
+    -fx-background-color: $ce;
+    -fx-text-fill: $c8;
+}
+
+#popupAutoComplete .list-cell:hover {
+    -fx-text-fill: $c8;
+}


### PR DESCRIPTION
still has a bug where suggestions cover command line when window is at the bottom of the screen
<img width="735" alt="Screenshot 2021-04-04 at 11 43 12 PM" src="https://user-images.githubusercontent.com/42601698/113514151-96f66180-959f-11eb-9d2e-7930e30f5f84.png">

New autocomplete provides support for autocompletion when ```tab```/```enter``` is pressed
Also, autocomplete suggestion box is hidden when user presses ```esc```