### PR TITLE
ID parsing related fixes

### DIFF
--- a/src/main/java/dog/pawbook/commons/core/Messages.java
+++ b/src/main/java/dog/pawbook/commons/core/Messages.java
@@ -22,6 +22,8 @@ public class Messages {
 
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s.";
 
+    public static final String MESSAGE_INVALID_ID_GENERAL =
+            String.format("ID must be a positive integer not exceeding %s!", Integer.MAX_VALUE);
     public static final String MESSAGE_INVALID_ID_FORMAT = "The %s ID provided is invalid.";
     public static final String MESSAGE_INVALID_ENTITY_ID = String.format(MESSAGE_INVALID_ID_FORMAT, "entity");
     public static final String MESSAGE_INVALID_OWNER_ID = String.format(MESSAGE_INVALID_ID_FORMAT, "owner");
@@ -39,6 +41,5 @@ public class Messages {
     public static final String MESSAGE_ENTITIES_LISTED_OVERVIEW_FOR_ONE = "1 entity listed!";
     public static final String MESSAGE_ENTITIES_LISTED_OVERVIEW = "%1$d entities listed!";
     public static final String MESSAGE_DOG_MISSING_OWNER_ID = "Dog to be added is missing owner ID.";
-    public static final String MESSAGE_NEGATIVE_ENTITY_ID = "Entity ID must be a positive integer!";
 
 }

--- a/src/main/java/dog/pawbook/logic/parser/ParserUtil.java
+++ b/src/main/java/dog/pawbook/logic/parser/ParserUtil.java
@@ -1,6 +1,6 @@
 package dog.pawbook.logic.parser;
 
-import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_ENTITY_ID;
+import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_ID_GENERAL;
 import static dog.pawbook.model.managedentity.dog.DateOfBirth.DATE_FORMAT;
 import static dog.pawbook.model.managedentity.dog.DateOfBirth.DATE_FORMATTER;
 import static dog.pawbook.model.managedentity.program.Session.DATETIME_FORMATTER;
@@ -201,11 +201,11 @@ public class ParserUtil {
      */
     public static int parseId(String id) throws ParseException {
         requireNonNull(id);
-        String trimmedOwnerId = id.trim();
+        String trimmedId = id.trim();
         try {
-            return Integer.parseInt(trimmedOwnerId);
+            return Integer.parseUnsignedInt(trimmedId);
         } catch (NumberFormatException e) {
-            throw new ParseException(MESSAGE_INVALID_ENTITY_ID);
+            throw new ParseException(MESSAGE_INVALID_ID_GENERAL);
         }
     }
 

--- a/src/main/java/dog/pawbook/logic/parser/ViewCommandParser.java
+++ b/src/main/java/dog/pawbook/logic/parser/ViewCommandParser.java
@@ -2,7 +2,7 @@
 package dog.pawbook.logic.parser;
 
 import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static dog.pawbook.commons.core.Messages.MESSAGE_NEGATIVE_ENTITY_ID;
+import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_ID_GENERAL;
 
 import dog.pawbook.logic.commands.ViewCommand;
 import dog.pawbook.logic.parser.exceptions.ParseException;
@@ -27,9 +27,7 @@ public class ViewCommandParser implements Parser<ViewCommand> {
         // Check if integer is valid
         int id = ParserUtil.parseId(trimmedArgs);
 
-        if (id < 1) {
-            throw new ParseException(MESSAGE_NEGATIVE_ENTITY_ID);
-        }
+        assert id > 0 : MESSAGE_INVALID_ID_GENERAL;
 
         return new ViewCommand(id);
     }

--- a/src/test/java/dog/pawbook/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/dog/pawbook/logic/parser/ViewCommandParserTest.java
@@ -3,8 +3,7 @@
 package dog.pawbook.logic.parser;
 
 import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_ENTITY_ID;
-import static dog.pawbook.commons.core.Messages.MESSAGE_NEGATIVE_ENTITY_ID;
+import static dog.pawbook.commons.core.Messages.MESSAGE_INVALID_ID_GENERAL;
 import static dog.pawbook.logic.commands.CommandTestUtil.INVALID_EMPTY_STRING;
 import static dog.pawbook.logic.commands.CommandTestUtil.INVALID_NEGATIVE_ID_STRING;
 import static dog.pawbook.logic.commands.CommandTestUtil.INVALID_UNKNOWN_ID_STRING;
@@ -41,13 +40,13 @@ public class ViewCommandParserTest {
     @Test
     public void parse_negativeId_parseException() {
         // Test that negative ID ParseException is thrown
-        assertParseFailure(parser, INVALID_NEGATIVE_ID_STRING, MESSAGE_NEGATIVE_ENTITY_ID);
+        assertParseFailure(parser, INVALID_NEGATIVE_ID_STRING, MESSAGE_INVALID_ID_GENERAL);
     }
 
     @Test
     public void parse_invalidId_parseException() {
         // Test that invalid ID parseException is thrown
-        assertParseFailure(parser, INVALID_UNKNOWN_ID_STRING, MESSAGE_INVALID_ENTITY_ID);
+        assertParseFailure(parser, INVALID_UNKNOWN_ID_STRING, MESSAGE_INVALID_ID_GENERAL);
     }
 
     @Test


### PR DESCRIPTION
Update the error message when ID is larger than signed 32-bit integer or an invalid string is given, also switch to `parseUnsignedInt` to detect negative IDs earlier.

Closes #385 