### PR TITLE
Fix regression that causes edit failure when name not edited

### DIFF
--- a/src/main/java/dog/pawbook/logic/commands/EditDogCommand.java
+++ b/src/main/java/dog/pawbook/logic/commands/EditDogCommand.java
@@ -67,7 +67,7 @@ public class EditDogCommand extends EditEntityCommand {
         Dog targetDog = (Dog) targetEntity;
         Dog editedDog = createEditedEntity(targetEntity, editEntityDescriptor);
 
-        if (!targetDog.equals(editedDog) && model.hasEntity(editedDog)) {
+        if (!targetDog.isSameAs(editedDog) && model.hasEntity(editedDog)) {
             throw new CommandException(getDuplicateEntityMessage());
         }
 

--- a/src/main/java/dog/pawbook/logic/commands/EditEntityCommand.java
+++ b/src/main/java/dog/pawbook/logic/commands/EditEntityCommand.java
@@ -77,7 +77,7 @@ public abstract class EditEntityCommand extends Command {
             throw new CommandException("Entity to edit does not match given entity type!");
         }
 
-        if (!targetEntity.equals(editedEntity) && model.hasEntity(editedEntity)) {
+        if (!targetEntity.isSameAs(editedEntity) && model.hasEntity(editedEntity)) {
             throw new CommandException(getDuplicateEntityMessage());
         }
 


### PR DESCRIPTION
The problem is with incomplete code change from the relaxation of
conditions that determine if entities are the same. Switched to isSameAs
from equals to resolve the issue.